### PR TITLE
prepare for garnix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,9 +43,11 @@
   nixConfig = {
     extra-substituters = [
       "https://cache.iog.io"
+      "https://cache.garnix.io"
     ];
     extra-trusted-public-keys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
     ];
     allow-import-from-derivation = true;
   };

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,3 @@
+builds:
+  include:
+  - 'checks.*.*'

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -9,6 +9,17 @@ in
 [
   (
     # Docs for project.flake: https://github.com/input-output-hk/iogx/blob/main/doc/api.md#mkhaskellprojectoutflake
-    project.flake
+    project.flake // {
+      checks = let
+        # https://github.com/numtide/flake-utils/issues/121#issuecomment-2589899217
+        recurseIntoDeepAttrs = attrs:
+          lib.recurseIntoAttrs (lib.mapAttrs (_: v:
+            if builtins.typeOf v == "set" && !lib.isDerivation v
+            then recurseIntoDeepAttrs v
+            else v
+          ) attrs);
+      in
+        inputs.iogx.inputs.flake-utils.lib.flattenTree (recurseIntoDeepAttrs project.flake.hydraJobs);
+    }
   )
 ]


### PR DESCRIPTION
- Add garnix cache to the flake nix config.
- Add `garnix.yaml` that builds only `.#checks`.
- Adjust the flake outputs to make garnix build everything that Hydra did.

Garnix does not build the `hydraJobs` output
so move them all into the `checks` output,
adhering to the flake output schema
because garnix does not build nested attrsets.

The `checks` output was previously empty.

Pre-submit checklist:
- Branch
    - ~~Tests are provided (if possible)~~
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - ~~Changelog fragments have been written (if appropriate)~~
    - ~~Relevant tickets are mentioned in commit messages~~
    - ~~Formatting, PNG optimization, etc. are updated~~
- PR
    - ~~(For external contributions) Corresponding issue exists and is linked in the description~~
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested