### PR TITLE
Import `Value` accessors from `PlutusLedgerApi.V3`

### DIFF
--- a/src/AuctionMintingPolicy.hs
+++ b/src/AuctionMintingPolicy.hs
@@ -1,8 +1,7 @@
 module AuctionMintingPolicy where
 
 import PlutusCore.Version (plcVersion110)
-import PlutusLedgerApi.V3 (PubKeyHash, ScriptContext (..), TxInfo (..), mintValueMinted)
-import PlutusLedgerApi.V1.Value (flattenValue)
+import PlutusLedgerApi.V3 (PubKeyHash, ScriptContext (..), TxInfo (..), flattenValue, mintValueMinted)
 import PlutusLedgerApi.V3.Contexts (ownCurrencySymbol, txSignedBy)
 import PlutusTx
 import PlutusTx.Prelude qualified as PlutusTx

--- a/src/AuctionValidator.hs
+++ b/src/AuctionValidator.hs
@@ -5,11 +5,11 @@ import GHC.Generics (Generic)
 import PlutusCore.Version (plcVersion110)
 import PlutusLedgerApi.V3 (CurrencySymbol, Datum (..), Lovelace, OutputDatum (..), 
                            POSIXTime, PubKeyHash, ScriptContext (..), TokenName, TxInfo (..), 
-                           TxOut (..), from, to, ScriptInfo (..), Redeemer (..), getRedeemer)
+                           TxOut (..), from, to, ScriptInfo (..), Redeemer (..), getRedeemer,
+                           lovelaceValueOf, valueOf)
 import PlutusLedgerApi.V3.Contexts (getContinuingOutputs)
 import PlutusLedgerApi.V1.Address (toPubKeyHash)
 import PlutusLedgerApi.V1.Interval (contains)
-import PlutusLedgerApi.V1.Value (lovelaceValueOf, valueOf)
 import PlutusTx
 import PlutusTx.AsData qualified as PlutusTx
 import PlutusTx.Blueprint


### PR DESCRIPTION
`AuctionValidator` and `AuctionMintingPolicy` are V3 scripts, but they read `Value` through `PlutusLedgerApi.V1.Value` (`lovelaceValueOf`, `valueOf`, `flattenValue`). Both already import everything else from `PlutusLedgerApi.V3`, so this moves the `Value` names there too.

The accessors reached `PlutusLedgerApi.V3` in plutus 1.66.0.0 (IntersectMBO/plutus#7839) and this repository is now pinned at 1.69.0.0, so the imports resolve. Rebased onto main after the sources moved under `template/`.

Prompted by a review comment from @zliu41 on IntersectMBO/plutus#7839.
